### PR TITLE
ミニプレーヤーへの遷移時のアニメーション実装

### DIFF
--- a/src/components/organisms/Room/LeftColumn.tsx
+++ b/src/components/organisms/Room/LeftColumn.tsx
@@ -1,13 +1,12 @@
 /** @jsx jsx */
 
-import * as React from 'react';
-import { jsx, css, SerializedStyles } from '@emotion/core';
-
-import { useResizeEvent } from 'util/hooks/window-events';
+import { useRef, useState } from 'react';
+import { jsx, css } from '@emotion/core';
 
 import RoomFooter from 'components/molecules/Footers/RoomFooter';
 import MainView, { RoomData } from 'components/organisms/Room/MainView';
 import VideoSearch from 'components/organisms/VideoSearch';
+import VideoWrapper from 'components/organisms/Room/VideoWrapper';
 import Video from 'components/organisms/Video';
 
 interface Props {
@@ -17,40 +16,9 @@ interface Props {
 }
 
 export default ({ room, isEditing, className }: Props) => {
-  const wrapperRef = React.useRef<HTMLDivElement>(null);
-  const videoAreaRef = React.useRef<HTMLDivElement>(null);
-  const [style, setStyle] = React.useState<SerializedStyles>();
-  const calcStyle = React.useCallback(() => {
-    if (isEditing) {
-      if (!wrapperRef.current) {
-        return;
-      }
-      const rect = wrapperRef.current.getBoundingClientRect();
-      const width = 320;
-      const height = 180;
-      setStyle(css`
-        position: fixed;
-        width: ${width}px;
-        height: ${height}px;
-        bottom: 20px;
-        left: ${rect.right - width}px;
-      `);
-    } else {
-      if (!videoAreaRef.current) {
-        return;
-      }
-      setStyle(css`
-        position: absolute;
-        top: ${videoAreaRef.current.offsetTop}px;
-        left: ${videoAreaRef.current.offsetLeft}px;
-        width: ${videoAreaRef.current.clientWidth}px;
-        height: ${videoAreaRef.current.clientHeight}px;
-      `);
-    }
-  }, [isEditing, wrapperRef, videoAreaRef]);
-
-  useResizeEvent(calcStyle);
-  React.useEffect(calcStyle, [isEditing, wrapperRef, videoAreaRef]);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const videoAreaRef = useRef<HTMLDivElement>(null);
+  const [isMinified, setIsMinified] = useState<boolean>();
 
   return (
     <div
@@ -61,13 +29,20 @@ export default ({ room, isEditing, className }: Props) => {
       className={className}
       ref={wrapperRef}
     >
-      {isEditing ? (
+      {isEditing && isMinified ? (
         <VideoSearch />
       ) : (
         <MainView {...room} videoAreaRef={videoAreaRef} />
       )}
       <RoomFooter />
-      {wrapperRef.current && <Video css={style} enableMiniPlayer={isEditing} />}
+      <VideoWrapper
+        isEditing={isEditing}
+        wrapperRef={wrapperRef}
+        areaRef={videoAreaRef}
+        onChanged={setIsMinified}
+      >
+        <Video enableMiniPlayer={isMinified} />
+      </VideoWrapper>
     </div>
   );
 };

--- a/src/components/organisms/Room/VideoWrapper.tsx
+++ b/src/components/organisms/Room/VideoWrapper.tsx
@@ -28,12 +28,10 @@ export default ({
   children,
 }: Props) => {
   const playerRef = useRef<HTMLDivElement>(null);
-  const [style, setStyle] = useState<SerializedStyles>(
-    css`
-      display: none;
-    `,
-  );
-  const [isMinified, setIsMinified] = useState<boolean>();
+  const initStyle = css`
+    display: none;
+  `;
+  const [style, setStyle] = useState<SerializedStyles>(initStyle);
   const animationSec = 0.4;
 
   const toMiniPlayer = useCallback(
@@ -46,36 +44,35 @@ export default ({
       const wrapperRect = wrapperElement.getBoundingClientRect();
       const width = 320;
       const height = 180;
-      const setBefore = (): void =>
-        setStyle(css`
-          position: fixed;
-          width: ${playerRect.width}px;
-          height: ${playerRect.height}px;
-          bottom: ${window.innerHeight - playerRect.bottom}px;
-          left: ${playerRect.left}px;
-        `);
-      const setAfter = (): void =>
-        setStyle(css`
-          ${enableAnimation &&
-            css`
-              transition: all ${animationSec}s ease;
-            `}
-          position: fixed;
-          width: ${width}px;
-          height: ${height}px;
-          bottom: 20px;
-          left: ${wrapperRect.right - width}px;
-        `);
+      const beforeStyle = css`
+        position: fixed;
+        width: ${playerRect.width}px;
+        height: ${playerRect.height}px;
+        bottom: ${window.innerHeight - playerRect.bottom}px;
+        left: ${playerRect.left}px;
+      `;
+      const afterStyle = css`
+        ${enableAnimation &&
+          css`
+            transition: all ${animationSec}s ease;
+          `}
+        position: fixed;
+        width: ${width}px;
+        height: ${height}px;
+        bottom: 20px;
+        left: ${wrapperRect.right - width}px;
+      `;
       if (enableAnimation) {
         window.requestAnimationFrame(() => {
-          setBefore();
+          setStyle(beforeStyle);
           window.requestAnimationFrame(() => {
-            setAfter();
+            setStyle(afterStyle);
           });
         });
       } else {
-        setAfter();
+        setStyle(afterStyle);
       }
+      onChanged(true);
     },
     [],
   );
@@ -89,37 +86,36 @@ export default ({
     ) => {
       const wrapperRect = wrapperElement.getBoundingClientRect();
       const playerRect = videoPlayerElement.getBoundingClientRect();
-      const setBefore = (): void =>
-        setStyle(css`
-          position: absolute;
-          top: ${playerRect.top - wrapperRect.top}px;
-          left: ${playerRect.left - wrapperRect.left}px;
-          width: ${playerRect.width}px;
-          height: ${playerRect.height}px;
-        `);
-      const setAfter = (): void =>
-        setStyle(css`
-          ${enableAnimation &&
-            css`
-              transition: all ${animationSec}s ease;
-            `}
-          position: absolute;
-          top: ${videoAreaElement.offsetTop}px;
-          left: ${videoAreaElement.offsetLeft}px;
-          width: ${videoAreaElement.clientWidth}px;
-          height: ${videoAreaElement.clientHeight}px;
-        `);
+      const beforeStyle = css`
+        position: absolute;
+        top: ${playerRect.top - wrapperRect.top}px;
+        left: ${playerRect.left - wrapperRect.left}px;
+        width: ${playerRect.width}px;
+        height: ${playerRect.height}px;
+      `;
+      const afterStyle = css`
+        ${enableAnimation &&
+          css`
+            transition: all ${animationSec}s ease;
+          `}
+        position: absolute;
+        top: ${videoAreaElement.offsetTop}px;
+        left: ${videoAreaElement.offsetLeft}px;
+        width: ${videoAreaElement.clientWidth}px;
+        height: ${videoAreaElement.clientHeight}px;
+      `;
 
       if (enableAnimation) {
         window.requestAnimationFrame(() => {
-          setBefore();
+          setStyle(beforeStyle);
           window.requestAnimationFrame(() => {
-            setAfter();
+            setStyle(afterStyle);
           });
         });
       } else {
-        setAfter();
+        setStyle(afterStyle);
       }
+      onChanged(false);
     },
     [],
   );
@@ -137,33 +133,24 @@ export default ({
 
   useResizeEvent(updateStyle);
   useEffect(() => {
-    if (isMinified === undefined) {
+    if (style === initStyle) {
       updateStyle();
-      setIsMinified(isEditing);
       return;
     }
     if (!wrapperRef.current || !playerRef.current) {
       return;
     }
-    if (isEditing && !isMinified) {
+    if (isEditing) {
       toMiniPlayer(wrapperRef.current, playerRef.current, true);
-      setIsMinified(isEditing);
-    } else if (!isEditing && isMinified && areaRef.current) {
+    } else if (areaRef.current) {
       toNormalPlayer(
         wrapperRef.current,
         areaRef.current,
         playerRef.current,
         true,
       );
-      setIsMinified(isEditing);
     }
   }, [isEditing]);
-
-  useEffect(() => {
-    if (isMinified !== undefined) {
-      onChanged(isMinified);
-    }
-  }, [isMinified]);
 
   return (
     <div css={style} ref={playerRef}>

--- a/src/components/organisms/Room/VideoWrapper.tsx
+++ b/src/components/organisms/Room/VideoWrapper.tsx
@@ -1,0 +1,173 @@
+/** @jsx jsx */
+
+import {
+  ReactNode,
+  RefObject,
+  useRef,
+  useState,
+  useCallback,
+  useEffect,
+} from 'react';
+import { jsx, css, SerializedStyles } from '@emotion/core';
+
+import { useResizeEvent } from 'util/hooks/window-events';
+
+interface Props {
+  isEditing: boolean;
+  wrapperRef: RefObject<HTMLDivElement>;
+  areaRef: RefObject<HTMLDivElement>;
+  children: ReactNode;
+  onChanged(editing: boolean): void;
+}
+
+export default ({
+  isEditing,
+  wrapperRef,
+  areaRef,
+  onChanged,
+  children,
+}: Props) => {
+  const playerRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState<SerializedStyles>(
+    css`
+      display: none;
+    `,
+  );
+  const [isMinified, setIsMinified] = useState<boolean>();
+  const animationSec = 0.4;
+
+  const toMiniPlayer = useCallback(
+    (
+      wrapperElement: HTMLDivElement,
+      videoPlayerElement: HTMLDivElement,
+      enableAnimation: boolean = false,
+    ) => {
+      const playerRect = videoPlayerElement.getBoundingClientRect();
+      const wrapperRect = wrapperElement.getBoundingClientRect();
+      const width = 320;
+      const height = 180;
+      const setBefore = (): void =>
+        setStyle(css`
+          position: fixed;
+          width: ${playerRect.width}px;
+          height: ${playerRect.height}px;
+          bottom: ${window.innerHeight - playerRect.bottom}px;
+          left: ${playerRect.left}px;
+        `);
+      const setAfter = (): void =>
+        setStyle(css`
+          ${enableAnimation &&
+            css`
+              transition: all ${animationSec}s ease;
+            `}
+          position: fixed;
+          width: ${width}px;
+          height: ${height}px;
+          bottom: 20px;
+          left: ${wrapperRect.right - width}px;
+        `);
+      if (enableAnimation) {
+        window.requestAnimationFrame(() => {
+          setBefore();
+          window.requestAnimationFrame(() => {
+            setAfter();
+          });
+        });
+      } else {
+        setAfter();
+      }
+    },
+    [],
+  );
+
+  const toNormalPlayer = useCallback(
+    (
+      wrapperElement: HTMLDivElement,
+      videoAreaElement: HTMLDivElement,
+      videoPlayerElement: HTMLDivElement,
+      enableAnimation: boolean = false,
+    ) => {
+      const wrapperRect = wrapperElement.getBoundingClientRect();
+      const playerRect = videoPlayerElement.getBoundingClientRect();
+      const setBefore = (): void =>
+        setStyle(css`
+          position: absolute;
+          top: ${playerRect.top - wrapperRect.top}px;
+          left: ${playerRect.left - wrapperRect.left}px;
+          width: ${playerRect.width}px;
+          height: ${playerRect.height}px;
+        `);
+      const setAfter = (): void =>
+        setStyle(css`
+          ${enableAnimation &&
+            css`
+              transition: all ${animationSec}s ease;
+            `}
+          position: absolute;
+          top: ${videoAreaElement.offsetTop}px;
+          left: ${videoAreaElement.offsetLeft}px;
+          width: ${videoAreaElement.clientWidth}px;
+          height: ${videoAreaElement.clientHeight}px;
+        `);
+
+      if (enableAnimation) {
+        window.requestAnimationFrame(() => {
+          setBefore();
+          window.requestAnimationFrame(() => {
+            setAfter();
+          });
+        });
+      } else {
+        setAfter();
+      }
+    },
+    [],
+  );
+
+  const updateStyle = useCallback(() => {
+    if (!wrapperRef.current || !playerRef.current) {
+      return;
+    }
+    if (isEditing) {
+      toMiniPlayer(wrapperRef.current, playerRef.current);
+    } else if (areaRef.current) {
+      toNormalPlayer(wrapperRef.current, areaRef.current, playerRef.current);
+    }
+  }, [isEditing]);
+
+  useResizeEvent(updateStyle);
+  useEffect(() => {
+    if (isMinified === undefined) {
+      updateStyle();
+      setIsMinified(isEditing);
+      return;
+    }
+    if (!wrapperRef.current || !playerRef.current) {
+      return;
+    }
+    if (isEditing && !isMinified) {
+      toMiniPlayer(wrapperRef.current, playerRef.current, true);
+      setIsMinified(isEditing);
+    } else if (!isEditing && isMinified && areaRef.current) {
+      toNormalPlayer(
+        wrapperRef.current,
+        areaRef.current,
+        playerRef.current,
+        true,
+      );
+      setIsMinified(isEditing);
+    }
+  }, [isEditing]);
+
+  useEffect(() => {
+    if (isMinified !== undefined) {
+      onChanged(isMinified);
+    }
+  }, [isMinified]);
+
+  return (
+    <div css={style} ref={playerRef}>
+      {children}
+    </div>
+  );
+};

--- a/src/components/organisms/Video/index.tsx
+++ b/src/components/organisms/Video/index.tsx
@@ -44,6 +44,8 @@ export default ({ className, enableMiniPlayer }: Props) => {
       css={css`
         background-color: #333333;
         color: #ffffff;
+        width: 100%;
+        height: 100%;
       `}
       className={className}
       onChange={handleFullScreenChange}


### PR DESCRIPTION
close #49
## 変更内容を記述してください。
* 通常プレーヤーとミニプレーヤーの変更時にanimationをつけた。
* （アニメーションなしの遷移時など）若干無駄な処理が走ってる部分がありますが、みやすさ重視にしました。

## 変更内容を確認する方法を教えてください。
* 正しくアニメーションが動作すること
* ルームページのプレイリストタブのプレイリスト編集ボタンを押す

## 他のプラットフォームで確認する事項等はありますか？
* とくになし

## スクリーンショット（before / after)
* 実際に触ってください。

<!---
### Pull Requestのタグ使い分け
Pull Requestには必ず以下のいずれかを付与し、状況が変化した場合はそれに合わせて変更すること。
* **wait for review**: レビュー待ち。
* **review complete**: レビュー済み。
* **WIP**: 作業途中。
-->
