### PR TITLE
safari / firefoxでフルスクリーンにならないバグの修正

### DIFF
--- a/src/components/atoms/FullScreens/BrowserFullScreen.tsx
+++ b/src/components/atoms/FullScreens/BrowserFullScreen.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import * as React from 'react';
+import { useRef, useState } from 'react';
 import { jsx, css } from '@emotion/core';
 
 import {
@@ -21,18 +21,17 @@ interface Props {
  * html5のbrowser full screen
  */
 export default ({ enable, children, className, onChange }: Props) => {
-  const ref = React.useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
+  const [prevEnable, setPrevEnable] = useState<boolean>();
 
-  React.useEffect(() => {
-    if (!ref.current) {
-      return;
-    }
+  if (enable !== prevEnable && ref.current) {
     if (enable) {
-      openFullScreen(ref);
+      openFullScreen(ref.current);
     } else {
       closeFullScreen();
     }
-  }, [enable, ref]);
+    setPrevEnable(enable);
+  }
 
   useFullScreenChange(() => {
     if (currentFullScreenElement() === ref.current) {

--- a/src/util/browser-api/full-screen.ts
+++ b/src/util/browser-api/full-screen.ts
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 export const currentFullScreenElement = (): Element | null => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const doc = document as any;
@@ -10,13 +8,13 @@ export const currentFullScreenElement = (): Element | null => {
   );
 };
 
-export const openFullScreen = (ref: React.RefObject<Element>): void => {
+export const openFullScreen = (element: Element): void => {
   if (currentFullScreenElement()) {
     return;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const el = ref.current as any;
+  const el = element as any;
 
   if (el.requestFullscreen) {
     el.requestFullscreen();


### PR DESCRIPTION
close #50
## 変更内容を記述してください。
* onClickのタイミングとopenFullScreenを呼ぶタイミングがずれていたため、safariとfirefoxでフルスクリーンにできなかった。
* componentのupdate後ではなく、update前にopenFullScreenを呼び出すようにした

## 変更内容を確認する方法を教えてください。
* safari / firefoxでフルスクリーンに移行できること

## 他のプラットフォームで確認する事項等はありますか？
なし

## スクリーンショット（before / after)
なし

<!---
### Pull Requestのタグ使い分け
Pull Requestには必ず以下のいずれかを付与し、状況が変化した場合はそれに合わせて変更すること。
* **wait for review**: レビュー待ち。
* **review complete**: レビュー済み。
* **WIP**: 作業途中。
-->
